### PR TITLE
Add section about formatting log messages

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -427,6 +427,15 @@ raise ValueError(
 ```
 
 
+### Formatting log messages
+
+You **should** use the following string format pattern for log messages, since this pattern is not calculated **unless** it is logged.
+
+```python
+logger.info("%s went %s wrong", 'Something', 'very')
+```
+
+
 ### Complex statements
 
 Statements with lots of operators can be broken up across multiple lines more

--- a/style-guide.md
+++ b/style-guide.md
@@ -429,7 +429,7 @@ raise ValueError(
 
 ### Formatting log messages
 
-You **should** use the following string format pattern for log messages, since this pattern is not calculated **unless** it is logged.
+You **should** use `%` style string formatting for log messages.  This allows for logging aggregators like [Sentry](https://sentry.io/) to group logging messages.
 
 ```python
 logger.info("%s went %s wrong", 'Something', 'very')


### PR DESCRIPTION
Added blurb about formatting log messages. Info scooped from [here](https://stackoverflow.com/questions/11589403/python-logger-string-formatting) and [here](https://reinout.vanrees.org/weblog/2015/06/05/logging-formatting.html).

fixes #19 