### PR TITLE
Add explicit else blocks to style guide

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -663,3 +663,37 @@ def foo():
     """
     pass
 ```
+
+# Flow Control
+
+## Explicit else blocks
+
+You **should** prefer to make alternative code paths explicit, even when an early return or raised exception makes it possible to do implicitly. For example, you **should** do this:
+
+```py
+if condition:
+  return True
+else:
+  return False
+```
+
+You **should not** do this:
+
+```py
+if condition:
+  return True
+
+return False
+```
+
+There are some exceptions. One exception is when a conditional short-circuit precedes a significant amount of logic, and is at the beginning of a method. In that case, you **may** choose to drop the explicit `else` block, like:
+
+```py
+def dothing(condition):
+  if not condition:
+    raise Exception('condition must be Truthy')
+  
+  do_a_thing()
+  then_do_more_things()
+  # etc...
+```


### PR DESCRIPTION
This is something that @pipermerriam and I have talked about a few times, and he convinced me that it's appealing to quickly/visually see the shape of the control flow. I think we are mildly consistent about following the pattern already. I've certainly given that feedback to external contributors as well.

I like it, but I don't feel super strongly about it. More important is for us to agree as a team, because the worst option is to use *both* conventions.

cc @ethereum/snake-charmers
_^ testing this out. Does it ping everyone on the team?_