### PR TITLE
Improve docs around releases

### DIFF
--- a/cutting-a-release.md
+++ b/cutting-a-release.md
@@ -1,47 +1,81 @@
-How to cut a new release:
+When to cut a new release
 ====
 
-Make sure to cut the release when there is time to support it if something goes wrong. As a rule, don't do releases late in the afternoon or on Fridays.
+Releases should be considered for each change that is merged to the main branch. Not all merges require a new version so it is reasonable to bundle several smaller changes together in a single release. All libraries should follow Continuous Delivery and Semver best practices. We typically release on Wednesdays and at minimum once per month (but could be longer for less prominent libraries).
 
-Steps:
-- [ ] Merge any outstanding PRs that are ready.
-- [ ] Double check that the tests ran (and passed) on the merged commit(s).
-- [ ] Pull down the branch that you'll cut the release from locally.
-- [ ] Make sure the dev dependencies are installed in your virtual environment. It may also be necessary to manually install the dependencies listed under the `setup_requires` keyword argument.
-- [ ] We use [Semantic Versioning](https://semver.org/) for all of our libraries. Decide which bump applies (major, minor, or patch) to the changes that will be relased. Here's a quick cheat sheet:
-  - Use a Major version bump when you make incompatible API changes
-  - Use a Minor version bump when you add functionality in a backwards-compatible manner
-  - Use a Patch version bump when you make backwards-compatible bug fixes
-- [ ] Make release notes before bumping the version number:
-  - Check the Makefile to see if there is a `make notes` command
-  - If there is a `make notes` command:
-    - [ ] From the command line run: `$ make notes bump=$$version part to bump$$`
-      - the "version part to bump" will usually be `major`, `minor`, or `patch`, but will sometimes be a devnum. Refer to the contributing guide in the docs for the library you're releasing to look at the syntax for
-      a devnum bump. For an example, check out the [web3.py Contributing Docs](https://web3py.readthedocs.io/en/stable/contributing.html#which-version-part-to-bump)
-    - [ ] Run `$ make docs` to view the release notes locally. Make sure everything looks like it should.
-  - If there is not a `make notes` command, you'll have to write the release notes manually.
-    - [ ] Look at the commits between the last version bump and the current one. Following the template already laid out in `docs/releases.rst`, write out what each unit of work does.
-      - Here are some categories that the units of work might fall under:
-        - Breaking Changes (only to be added in a major version bump)
-        - Bugfixes
-        - Deprecation
-        - Docs
-        - Features
-        - Internal
-        - Misc
-        - Performance
-        - Removal (only to be added in a major version bump)
-    - [ ] Run `$ make docs` to view the release notes locally. Make sure everything looks like it should.
-    - [ ] Once the docs look good, commit the changes.
-    - [ ] Push the doc changes to master.
-- [ ] Most repos have a section in either the README or the Contributing section of the docs that describes how to use the `make release` script. It looks something like [this](https://web3py.readthedocs.io/en/stable/contributing.html#releasing). Follow those instructions. Usually, it looks something like `$ make release bump=$$version part to bump$$`.
-  - Troubleshooting:
-    - If something goes wrong in the middle, you'll need to figure out what went wrong and fix that problem
-    - Open up the Makefile, and run the failed command and all subsequent commands manually
-    - If the problem persists, you may be able to skip the command and run the subsequent commands manually
-- [ ] Test it!
-  - Create and activate a new virtualenv
-  - `$ pip install -U <released_project>`
-  - Open shell and confirm that the module import works. Check a simple feature and/or new features
-- [ ] Make sure the ReadTheDocs build succeeded. Visit the `https://<project name>.readthedocs.io/en/stable/releases.html` and make sure your changes are there.
-- [ ] Announce to the Discord channel if it's a user-facing library. Typically this announcement includes a link to the release notes. :tada:
+> :warning: Make sure to cut the release when there is time to support it if something goes wrong. As a rule, don't do releases late in the afternoon or on Fridays.
+
+The team should review any outstanding PRs and recent merges at the weekly sync. If there are any newsfragments in the main branch there is a good chance a release is needed.
+
+How to cut a new release
+====
+
+A release of a library requires a version bump, compiling release notes, and publishing to PyPI.
+
+### Releasing with Semver
+
+We use [Semantic Versioning](https://semver.org/) for all of our libraries. Decide which bump applies (major, minor, or patch) to the changes that will be relased. Here's a quick cheat sheet:
+  - Use a `major` version bump when you make incompatible API changes
+  - Use a `minor` version bump when you add functionality in a backwards-compatible manner
+  - Use a `patch` version bump when you make backwards-compatible bug fixes
+
+Follow the sections below to release with the desired version.
+
+### Requirements
+
+  1. Changes are merged in the main branch
+  2. The latest build on the main branch was successful
+
+### Steps
+
+  1. From your local copy of the lib's repository, check out and pull the latest from the main branch.
+  1. Activate your virtual environment and run `python -m pip install -e ".[dev]"` to ensure the latest dev dependencies are installed.
+      * It may be necessary to manually install dependencies listed under the `setup_requires` keyword.
+  1. Verify documentation and release notes
+      * Run `make docs` to preview and verify the docs pages.
+      * Run `towncrier build --draft` to verify the release notes.
+  1. Generate release notes with `make notes bump=<major,minor,patch>`.
+  1. The remaining steps are run via `make release bump=<major,minor,patch>` command. This will typically build the docs, bump the version, push the tags to GitHub, and build and publish the package to PyPI.
+
+If any of the commands fail, make sure the release is performed to completion. Once you have resolved the issue, run the remaining commands manually and verify the package is available.
+
+### Final Verification
+
+1. Make sure to install the new version and confirm everything is working.
+    * Create and activate a new virtualenv, then run `$ pip install -U <released_project>`
+2. Check the latest documentation is published on ReadTheDocs.
+    * Also check the ReadTheDocs build succeeded at `https://<project name>.readthedocs.io/en/stable/releases.html`
+
+### New Version Announcement
+
+If the release was for a user-facing library, announce the latest version in the [web3py Discord channel](https://discord.com/channels/809793915578089484/817614427490615307). Typically this announcement includes a link to the release notes. :tada:
+
+
+
+## Release FAQ
+
+### **Q: The `make release` command failed with "`The user '<username>' isn't allowed to upload to project '<project name>'`"**
+
+**A:** This occurs when you do not have permissions set on your PyPI account. Reach out to the team to get access.
+
+### **Q: What can I do if there is not a `make notes` command?**
+
+**A:** In this case, the release notes must be created manually. The following steps outline this process:
+
+1. Modify the release notes in `docs/releases.rst` to add a section for the new version.
+1. Create subsections to categorize each of the changes that were made.
+
+    ### Subsections/Categories
+    - Breaking Changes (only to be added in a major version bump)
+    - Bugfixes
+    - Deprecation
+    - Docs
+    - Features
+    - Internal
+    - Misc
+    - Performance
+    - Removal (only to be added in a major version bump)
+
+1. Verify documentation and release notes
+    * Run `make docs` to preview and verify the docs pages.
+1. Commit the changes to the main branch and push to the upstream repo with `git push upstream`.

--- a/cutting-a-release.md
+++ b/cutting-a-release.md
@@ -14,7 +14,7 @@ A release of a library requires a version bump, compiling release notes, and pub
 
 ### Releasing with Semver
 
-We use [Semantic Versioning](https://semver.org/) for all of our libraries. Decide which bump applies (major, minor, or patch) to the changes that will be relased. Here's a quick cheat sheet:
+We use [Semantic Versioning](https://semver.org/) for all of our libraries. Decide which bump applies (major, minor, or patch) to the changes that will be released. Here's a quick cheat sheet:
   - Use a `major` version bump when you make incompatible API changes
   - Use a `minor` version bump when you add functionality in a backwards-compatible manner
   - Use a `patch` version bump when you make backwards-compatible bug fixes
@@ -29,13 +29,13 @@ Follow the sections below to release with the desired version.
 ### Steps
 
   1. From your local copy of the lib's repository, check out and pull the latest from the main branch.
-  1. Activate your virtual environment and run `python -m pip install -e ".[dev]"` to ensure the latest dev dependencies are installed.
+  2. Activate your virtual environment and run `python -m pip install -e ".[dev]"` to ensure the latest dev dependencies are installed.
       * It may be necessary to manually install dependencies listed under the `setup_requires` keyword.
-  1. Verify documentation and release notes
+  3. Verify documentation and release notes
       * Run `make docs` to preview and verify the docs pages.
       * Run `towncrier build --draft` to verify the release notes.
-  1. Generate release notes with `make notes bump=<major,minor,patch>`.
-  1. The remaining steps are run via `make release bump=<major,minor,patch>` command. This will typically build the docs, bump the version, push the tags to GitHub, and build and publish the package to PyPI.
+  4. Generate release notes with `make notes bump=<major,minor,patch>`.
+  5. The remaining steps are run via `make release bump=<major,minor,patch>` command. This will typically build the docs, bump the version, push the tags to GitHub, and build and publish the package to PyPI.
 
 If any of the commands fail, make sure the release is performed to completion. Once you have resolved the issue, run the remaining commands manually and verify the package is available.
 
@@ -63,7 +63,7 @@ If the release was for a user-facing library, announce the latest version in the
 **A:** In this case, the release notes must be created manually. The following steps outline this process:
 
 1. Modify the release notes in `docs/releases.rst` to add a section for the new version.
-1. Create subsections to categorize each of the changes that were made.
+2. Create subsections to categorize each of the changes that were made.
 
     ### Subsections/Categories
     - Breaking Changes (only to be added in a major version bump)
@@ -76,6 +76,6 @@ If the release was for a user-facing library, announce the latest version in the
     - Performance
     - Removal (only to be added in a major version bump)
 
-1. Verify documentation and release notes
+3. Verify documentation and release notes
     * Run `make docs` to preview and verify the docs pages.
-1. Commit the changes to the main branch and push to the upstream repo with `git push upstream`.
+4. Commit the changes to the main branch and push to the upstream repo with `git push upstream`.

--- a/git-and-github.md
+++ b/git-and-github.md
@@ -140,6 +140,8 @@ Recommended Reading:
 
 Once your pull request has been *Approved* it may be merged at your discretion.  In most cases responsibility for merging is left to the person who opened the pull request, however for simple pull requests it is fine for anyone to merge.
 
+Please use `Squash and Merge` to keep the commit history clean on the main branch.
+
 If substantive changes are made **after** the pull request has been marked *Approved* you should ask for an additional round of review.
 
 

--- a/git-and-github.md
+++ b/git-and-github.md
@@ -88,7 +88,7 @@ The *correct* phrasing of a commit message.
 - `fixes bug #1234` (wrong)
 - `fixing bug #1234` (wrong)
 
-One way to test if you have it write is to complete the following sentence.
+One way to test if you have it right is to complete the following sentence.
 
 > If you apply this commit it will ________________.
 
@@ -140,7 +140,11 @@ Recommended Reading:
 
 Once your pull request has been *Approved* it may be merged at your discretion.  In most cases responsibility for merging is left to the person who opened the pull request, however for simple pull requests it is fine for anyone to merge.
 
-Please use `Squash and Merge` to keep the commit history clean on the main branch.
+When merging, please avoid the `Create a merge commit` option as this may have undesired outcomes by having each commit on the main branch. Ideally, the commits have been cleaned up, following best practices outlined in [Commit Hygiene](#commit-hygiene) above.
+
+> Use `Squash and merge` if you want to combine all your commits  into a single commit on the main branch. Make sure you have rebased your branch prior to choosing this option.
+
+> Use `Rebase and merge` if you want to keep the commits and ensure it is applied starting from HEAD of the main branch.
 
 If substantive changes are made **after** the pull request has been marked *Approved* you should ask for an additional round of review.
 

--- a/git-and-github.md
+++ b/git-and-github.md
@@ -142,7 +142,7 @@ Once your pull request has been *Approved* it may be merged at your discretion. 
 
 When merging, please avoid the `Create a merge commit` option as this may have undesired outcomes by having each commit on the main branch. Ideally, the commits have been cleaned up, following best practices outlined in [Commit Hygiene](#commit-hygiene) above.
 
-> Use `Squash and merge` if you want to combine all your commits  into a single commit on the main branch. Make sure you have rebased your branch prior to choosing this option.
+> Use `Squash and merge` if you want to combine all your commits into a single commit on the main branch. Make sure you have rebased your branch prior to choosing this option.
 
 > Use `Rebase and merge` if you want to keep the commits and ensure it is applied starting from HEAD of the main branch.
 


### PR DESCRIPTION
Revamped the release guide, mainly to outline our process and agreements. While I was there I simplified the steps for the most common approach and moved the ancillary notes into a new FAQ section.