### PR TITLE
change branch master to main

### DIFF
--- a/git-and-github.md
+++ b/git-and-github.md
@@ -66,7 +66,7 @@ This means that each commit contains one logical change to the code.  For exampl
 - commit `C` modifies the configuration for CI.
 
 This approach is sometimes easier to do *after* all of the code has been
-written.  Once things are complete, you can `git reset master` to unstage all
+written.  Once things are complete, you can `git reset main` to unstage all
 of the changes you've made, and then re-commit them in small chunks using `git
 add -p`.
 

--- a/template.md
+++ b/template.md
@@ -50,11 +50,11 @@ In this case, add the template as a remote this way:
 git remote add template-host git@github.com:ethereum/ethereum-python-project-template.git
 ```
 
-Then check out the master of the template repo as a local branch called `template`:
+Then check out the main of the template repo as a local branch called `template`:
 
 ```sh
 git fetch template-host
-git checkout --track -b template template-host/master
+git checkout --track -b template template-host/main
 ```
 
 ### Pull in the latest template changes
@@ -69,7 +69,7 @@ git pull
 #### Create a template upgrade feature branch
 
 ```sh
-git checkout master
+git checkout main
 git pull
 git checkout -b upgrade-template
 ```
@@ -153,14 +153,14 @@ get fetch tmpl
 
 Check out the template on a local branch:
 ```sh
-git checkout -b template tmpl/master
+git checkout -b template tmpl/main
 ```
 
 ### Merge in the template
 
 We want to force a merge, even though the repositories have no shared history.
 ```sh
-git checkout -b join-to-template master
+git checkout -b join-to-template main
 git merge --allow-unrelated-histories template
 ```
 

--- a/testing.md
+++ b/testing.md
@@ -26,9 +26,9 @@ for testing.
 Where possible, test suites should mirror the module structure of their
 corresponding package.  For example, the
 [`eth-abi`](https://github.com/ethereum/eth-abi) package has a submodule called
-[`eth_abi.grammar`](https://github.com/ethereum/eth-abi/blob/master/eth_abi/grammar.py).
+[`eth_abi.grammar`](https://github.com/ethereum/eth-abi/blob/main/eth_abi/grammar.py).
 Accordingly, it has a testing module called
-[`tests.grammar`](https://github.com/ethereum/eth-abi/blob/master/tests/grammar.py)
+[`tests.grammar`](https://github.com/ethereum/eth-abi/blob/main/tests/grammar.py)
 that contains testing routines for resources provided by the `eth_abi.grammar`
 module.
 


### PR DESCRIPTION
Change refs to the branch `master` to `main`.

`eth-abi` hasn't technically changed yet, but will be done soon.